### PR TITLE
Shell media init fix : Load class Folder in the shell (the 2.0 way)

### DIFF
--- a/Console/Command/MediaShell.php
+++ b/Console/Command/MediaShell.php
@@ -18,7 +18,7 @@
  */
 App::uses('ConnectionManager', 'Model');
 require_once(App::path('Config', 'Media').'core.php');
-
+App::uses('Folder', 'Utility');
 
 Configure::write('Cache.disable', true);
 


### PR DESCRIPTION
Load class Folder in the shell (2.0 way), necessary to initialize the directories using media init
