### PR TITLE
Fix filters logic

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -236,12 +236,12 @@ $m = array('convert' => 'image/jpeg', 'fit' => array(300, 300));
 $l = array('convert' => 'image/jpeg', 'fit' => array(600, 440));
 $original = array('clone'=>'copy');
 
-Configure::write('Media.filter', array('default' => array(
+Configure::write('Media.filter', array(
 	'audio' => compact('s', 'm'),
 	'document' => compact('s', 'm','original'),
 	'generic' => array('original'=>array('clone'=>'copy')),
 	'image' => compact('s', 'm', 'l','original'),
 	'video' => compact('s', 'm')
-)));
+));
 
 ?>

--- a/Model/Behavior/GeneratorBehavior.php
+++ b/Model/Behavior/GeneratorBehavior.php
@@ -346,41 +346,6 @@ class GeneratorBehavior extends ModelBehavior {
 		}
 		return array($file, $relativeFile);
 	}
-
-	public function setFilter($Model, $filter = null) {
-		$this->settings[$Model->alias]['filter'] = $filter;
-	}
-
-/**
- * Returns the configured filter array
- *
- * @param Model $Model
- * @param string $file
- * @return array
- */
-	public function filter($Model, $file) {
-		$name = Mime_Type::guessName($file);
-
-		$filter = $this->settings[$Model->alias]['filter'];
-
-		$default = false;
-		if (!is_array($filter)) {
-			$filters = Configure::read('Media.filter');
-
-			if (is_string($filter) && isset($filters[$filter])) {
-				$filter = $filters[$filter];
-			} else {
-				$filter = $filters['default'];
-				$default = true;
-			}
-		}
-
-		if (($default !== true) && ($this->settings[$Model->alias]['mergeFilter'] === true)) {
-			$filter = array_merge($filters['default'], (array)$filter);
-		}
-
-		return $filter[$name];
-    }
 }
 
 ?>


### PR DESCRIPTION
Since as of commit d0b8f5985b8fbc587d0e57cf093bc48a0328905f the use of
different filter configurations no longer works (why not, makes it
simpler), might as well remove the corresponding functions and update
default configuration in bootstrap.
