### PR TITLE
Fixing Versions for different configs

### DIFF
--- a/Model/Behavior/GeneratorBehavior.php
+++ b/Model/Behavior/GeneratorBehavior.php
@@ -156,7 +156,13 @@ class GeneratorBehavior extends ModelBehavior {
 		list($file, $relativeFile) = $this->_file($Model, $file);
 		$relativeDirectory = DS . rtrim(dirname($relativeFile), '.');
 
-		$filter = Configure::read('Media.filter.' . Mime_Type::guessName($file));;
+		//$filter = Configure::read('Media.filter.' . Mime_Type::guessName($file));;
+		$filter = Configure::read('Media.filter');
+		if (isset($filter[$Model->alias])) {
+		    $filter = $filter[$Model->alias][Mime_Type::guessName($file)];
+		} else {
+		    $filter = $filter['default'][Mime_Type::guessName($file)];
+		}
 		$result = true;
 
 		foreach ($filter as $version => $instructions) {


### PR DESCRIPTION
Just inserted back the old Generator logic for different versions and fixed the missing logic for different filters, depending on Model->alias i.e.

Configure::write('Media.filter.default.image', array(
    's' => array('convert' => 'image/jpeg', 'fit' => array(300, 300), 'compress' => 6)
));
Configure::write('Media.filter.ModelAlias.image', array(
    's' => array('convert' => 'image/jpeg', 'fit' => array(220, 220), 'compress' => 4)
));
