### PR TITLE
TransferBehavior: Add support for simple rules and one-rule-per-field validation

### DIFF
--- a/Model/Behavior/TransferBehavior.php
+++ b/Model/Behavior/TransferBehavior.php
@@ -129,9 +129,22 @@ class TransferBehavior extends ModelBehavior {
 	public function setup(Model $Model, $settings = array()) {
 		/* If present validation rules get some sane default values */
 		if (isset($Model->validate['file'])) {
-			$default = array('allowEmpty' => true, 'required' => false, 'last' => true);
+			$validate = &$Model->validate;
 
-			foreach ($Model->validate['file'] as &$rule) {
+			if (!is_array($validate['file'])) {
+				$validate['file'] = array(
+					'rule' => $validate['file']
+				);
+			}
+
+			if (is_array($validate['file']) && isset($validate['file']['rule'])) {
+				$validate['file'] = array(
+					$validate['file']['rule'] => $validate['file']
+				);
+			}
+
+			$default = array('allowEmpty' => true, 'required' => false, 'last' => true);
+			foreach ($validate['file'] as &$rule) {
 				$rule = array_merge($default, $rule);
 			}
 		}

--- a/Test/Case/Model/Behavior/TransferBehaviorTest.php
+++ b/Test/Case/Model/Behavior/TransferBehaviorTest.php
@@ -97,6 +97,81 @@ class TransferBehaviorTest extends BaseBehaviorTest {
 			)
 		);
 		$this->assertEqual($Model->validate['file'], $expected);
+
+		$Model = ClassRegistry::init('Movie');
+		$Model->validate['file'] = array(
+			'resource' => array(
+				'rule'     => 'checkResource',
+				'required' => true,
+			),
+			'access'   => array(
+				'rule' => 'checkAccess'
+			)
+		);
+		$Model->Behaviors->load('Media.Transfer');
+
+		$expected = array(
+			'resource' => array(
+				'rule'       => 'checkResource',
+				'allowEmpty' => true,
+				'required'   => true,
+				'last'       => true
+			),
+			'access'   => array(
+				'rule' => 'checkAccess',
+				'allowEmpty' => true,
+				'required'   => false,
+				'last'       => true
+			)
+		);
+		$this->assertEqual($Model->validate['file'], $expected);
+
+		$Model = ClassRegistry::init('Movie');
+		$Model->validate['file'] = array(
+			'rule' => 'checkResource'
+		);
+		$Model->Behaviors->load('Media.Transfer');
+
+		$expected = array(
+			'checkResource' => array(
+				'rule'       => 'checkResource',
+				'allowEmpty' => true,
+				'required'   => false,
+				'last'       => true
+			)
+		);
+		$this->assertEqual($Model->validate['file'], $expected);
+
+		$Model = ClassRegistry::init('Movie');
+		$Model->validate['file'] = array(
+			'rule' => 'checkResource',
+			'required' => true
+		);
+		$Model->Behaviors->load('Media.Transfer');
+
+		$expected = array(
+			'checkResource' => array(
+				'rule'       => 'checkResource',
+				'allowEmpty' => true,
+				'required'   => true,
+				'last'       => true
+			)
+		);
+		$this->assertEqual($Model->validate['file'], $expected);
+
+		$Model = ClassRegistry::init('Movie');
+		$Model->validate['file'] = 'checkResource';
+		$Model->Behaviors->load('Media.Transfer');
+
+		$expected = array(
+			'checkResource' => array(
+				'rule'       => 'checkResource',
+				'allowEmpty' => true,
+				'required'   => false,
+				'last'       => true
+			)
+		);
+		$this->assertEqual($Model->validate['file'], $expected);
 	}
 
 	public function testFailOnNoResource() {


### PR DESCRIPTION
This patch adds support for using simple rules:

``` php
public $validate = array(
    'file' => 'ruleName'
);
```

as well as the one-rule-per-field style:

``` php
public $validate = array(
    'file' => array(
        'rule' => 'ruleName'
    )
);
```

while keeping the "merge with default validation options" behavior.
