### PR TITLE
Revamp MediaHelper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,15 @@ before_script:
         'trace' => true
       ));
     }" >> ./app/Config/bootstrap.php
+  - echo "<?php
+    \$config = array(
+      'tags' => array(
+        'foo' => '<foo%s/>'
+      ),
+      'minimizedAttributes' => array(
+        'qux'
+      )
+    );" > ./app/Config/media_helper.php
 
 script:
   - ./lib/Cake/Console/cake $CAKEPHP_SHELL_NAME Media AllTests --stderr

--- a/Config/media_helper.php
+++ b/Config/media_helper.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Media helper configuration file
+ *
+ * PHP 5
+ * CakePHP 2
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author        Oliver Nowak <info@nowak-media.de>
+ * @package       Media.Config
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+$config = array(
+	'tags' => array(
+		'audio'  => '<audio%s>%s%s</audio>',
+		'video'  => '<video%s>%s%s</video>',
+		'source' => '<source%s/>',
+		'object' => '<object%s>%s%s</object>',
+		'param'  => '<param%s/>'
+	),
+	'minimizedAttributes' => array(
+		'autobuffer',
+		'autoplay',
+		'checked',
+		'compact',
+		'controls',
+		'declare',
+		'defer',
+		'disabled',
+		'formnovalidate',
+		'ismap',
+		'loop',
+		'multiple',
+		'muted',
+		'nohref',
+		'noresize',
+		'noshade',
+		'novalidate',
+		'nowrap',
+		'readonly',
+		'required',
+		'selected'
+	)
+);

--- a/Test/Case/View/Helper/MediaHelperTest.php
+++ b/Test/Case/View/Helper/MediaHelperTest.php
@@ -206,6 +206,21 @@ class MediaHelperTest extends CakeTestCase {
 	}
 
 	public function testEmbed() {
+		$result = $this->Media->embed('img/image-png', array(
+			'url' => 'http://example.com'
+		));
+		$expected = '<a href="http://example.com"><img src="/media/static/img/image-png.png"  height="54" width="70"/></a>';
+		$this->assertEqual($result, $expected);
+
+		$result = $this->Media->embed('img/image-png', array(
+			'checked'  => true,
+			'disabled' => true,
+			'noresize' => true,
+			'required' => true
+		));
+		$expected = '<img src="/media/static/img/image-png.png"  checked="checked" disabled="disabled" noresize="noresize" required="required" height="54" width="70"/>';
+		$this->assertEqual($result, $expected);
+
 		$this->Data->getFile(array(
 			'audio-mp3.mp3' => $this->Data->settings['special'] . 'img/special-audio-&-mp3.mp3'
 		));
@@ -260,6 +275,21 @@ class MediaHelperTest extends CakeTestCase {
 	}
 
 	public function testEmbedAsObject() {
+		$result = $this->Media->embedAsObject('img/image-png', array(
+			'url' => 'http://example.com'
+		));
+		$expected = '<a href="http://example.com"><img src="/media/static/img/image-png.png"  height="54" width="70"/></a>';
+		$this->assertEqual($result, $expected);
+
+		$result = $this->Media->embedAsObject('img/image-png', array(
+			'checked'  => true,
+			'disabled' => true,
+			'noresize' => true,
+			'required' => true
+		));
+		$expected = '<object type="image/png" data="/media/static/img/image-png.png" checked="checked" disabled="disabled" noresize="noresize" required="required"><param name="src" value="/media/static/img/image-png.png"/></object>';
+		$this->assertEqual($result, $expected);
+
 		$result = $this->Media->embedAsObject('img/special-image-&-png');
 		$expected = '<object type="image/png" data="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png"><param name="src" value="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png"/></object>';
 		$this->assertEqual($result, $expected);

--- a/Test/Case/View/Helper/MediaHelperTest.php
+++ b/Test/Case/View/Helper/MediaHelperTest.php
@@ -135,6 +135,30 @@ class MediaHelperTest extends CakeTestCase {
 		$this->assertEqual($result, $expected);
 	}
 
+	public function testConstructWithCustomPathsAndConfigFile() {
+		$settings = array(
+			'configFile' => 'media_helper.php',
+			'paths' => array(
+				$this->Data->settings['static']               => 'media/static/',
+				$this->Data->settings['base'] . 'theme' . DS  => 'media/theme/'
+			),
+		);
+		$MediaHelper = new MockMediaHelper($this->View, $settings);
+
+		$result = $MediaHelper->paths();
+		$expected = array(
+			$this->Data->settings['static']               => MEDIA_STATIC_URL,
+			MEDIA_TRANSFER                                => MEDIA_TRANSFER_URL,
+			MEDIA_FILTER                                  => MEDIA_FILTER_URL,
+			$this->Data->settings['base'] . 'theme' . DS  => 'media/theme/'
+		);
+		$this->assertEqual($result, $expected);
+
+		$result = $MediaHelper->Html->useTag('foo', array('bar' => 'baz', 'qux' => true));
+		$expected = '<foo bar="baz" qux="qux"/>';
+		$this->assertEqual($result, $expected);
+	}
+
 	public function testUrl() {
 		$result = $this->Media->url('img/special-image-&-png');
 		$this->assertEqual($result, 'http://fo&o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png');
@@ -186,18 +210,18 @@ class MediaHelperTest extends CakeTestCase {
 			'audio-mp3.mp3' => $this->Data->settings['special'] . 'img/special-audio-&-mp3.mp3'
 		));
 		$result = $this->Media->embed('img/special-audio-&-mp3');
-		$expected = '<audio controls="controls"><source src="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-audio-%26-mp3.mp3" type="audio/mpeg" /></audio>';
+		$expected = '<audio controls="controls"><source src="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-audio-%26-mp3.mp3" type="audio/mpeg"/></audio>';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Media->embed('img/special-image-&-png');
-		$expected = '<img src="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png"  height="54" width="70" />';
+		$expected = '<img src="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png"  height="54" width="70"/>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'video-wmv.wmv' => $this->Data->settings['special'] . 'img/special-video-&-wmv.wmv'
 		));
 		$result = $this->Media->embed('img/special-video-&-wmv');
-		$expected = '<video controls="controls"><source src="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-video-%26-wmv.wmv" type="video/x-ms-wmv" /></video>';
+		$expected = '<video controls="controls"><source src="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-video-%26-wmv.wmv" type="video/x-ms-wmv"/></video>';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Media->embed('img/image-png', array(
@@ -205,29 +229,29 @@ class MediaHelperTest extends CakeTestCase {
 			'class' => 'image',
 			'data-custom' => 42
 		));
-		$expected = '<img src="/media/static/img/image-png.png"  id="my-image" class="image" data-custom="42" height="54" width="70" />';
+		$expected = '<img src="/media/static/img/image-png.png"  id="my-image" class="image" data-custom="42" height="54" width="70"/>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'audio-mp3.mp3' => $this->Data->settings['static'] . 'aud/audio-mp3.mp3'
 		));
 		$result = $this->Media->embed('aud/audio-mp3');
-		$expected = '<audio controls="controls"><source src="/media/static/aud/audio-mp3.mp3" type="audio/mpeg" /></audio>';
+		$expected = '<audio controls="controls"><source src="/media/static/aud/audio-mp3.mp3" type="audio/mpeg"/></audio>';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Media->embed('img/image-png');
-		$expected = '<img src="/media/static/img/image-png.png"  height="54" width="70" />';
+		$expected = '<img src="/media/static/img/image-png.png"  height="54" width="70"/>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'video-wmv.wmv' => $this->Data->settings['static'] . 'vid/video-wmv.wmv'
 		));
 		$result = $this->Media->embed('vid/video-wmv');
-		$expected = '<video controls="controls"><source src="/media/static/vid/video-wmv.wmv" type="video/x-ms-wmv" /></video>';
+		$expected = '<video controls="controls"><source src="/media/static/vid/video-wmv.wmv" type="video/x-ms-wmv"/></video>';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Media->embed('vid/video-wmv', array('poster' => $this->file0));
-		$expected = '<video height="54" width="70" poster="/media/static/img/image-png.png" controls="controls"><source src="/media/static/vid/video-wmv.wmv" type="video/x-ms-wmv" /></video>';
+		$expected = '<video height="54" width="70" controls="controls" poster="/media/static/img/image-png.png"><source src="/media/static/vid/video-wmv.wmv" type="video/x-ms-wmv"/></video>';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Media->embed('non-existent');
@@ -237,7 +261,7 @@ class MediaHelperTest extends CakeTestCase {
 
 	public function testEmbedAsObject() {
 		$result = $this->Media->embedAsObject('img/special-image-&-png');
-		$expected = '<object type="image/png" data="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png" ><param name="src" value="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png" /></object>';
+		$expected = '<object type="image/png" data="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png"><param name="src" value="http://fo&amp;o:bar@example.com/media/special%5Bfolder%5D/img/special-image-%26-png.png"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Media->embedAsObject('img/image-png', array(
@@ -245,29 +269,29 @@ class MediaHelperTest extends CakeTestCase {
 			'class' => 'image',
 			'data-custom' => 42
 		));
-		$expected = '<object type="image/png" data="/media/static/img/image-png.png" id="my-image" class="image" data-custom="42" ><param name="src" value="/media/static/img/image-png.png" /></object>';
+		$expected = '<object type="image/png" data="/media/static/img/image-png.png" id="my-image" class="image" data-custom="42"><param name="src" value="/media/static/img/image-png.png"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'video-wmv.wmv' => $this->Data->settings['static'] . 'vid/video-wmv.wmv'
 		));
 		$result = $this->Media->embedAsObject('vid/video-wmv');
-		$expected = '<object type="video/x-ms-wmv" data="/media/static/vid/video-wmv.wmv" classid="clsid:6BF52A52-394A-11d3-B153-00C04F79FAA6" ><param name="src" value="/media/static/vid/video-wmv.wmv" />
-<param name="controller" value="true" />
-<param name="pluginspage" value="http://www.microsoft.com/Windows/MediaPlayer/" /></object>';
+		$expected = '<object type="video/x-ms-wmv" data="/media/static/vid/video-wmv.wmv" classid="clsid:6BF52A52-394A-11d3-B153-00C04F79FAA6"><param name="src" value="/media/static/vid/video-wmv.wmv"/>
+<param name="controller" value="true"/>
+<param name="pluginspage" value="http://www.microsoft.com/Windows/MediaPlayer/"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'video-rm.rm' => $this->Data->settings['static'] . 'vid/video-rm.rm'
 		));
 		$result = $this->Media->embedAsObject('vid/video-rm');
-		$expected = '<object type="application/vnd.rn-realmedia" data="/media/static/vid/video-rm.rm" classid="clsid:CFCDAA03-8BE4-11cf-B84B-0020AFBBCCFA" ><param name="src" value="/media/static/vid/video-rm.rm" />
-<param name="controls" value="ControlPanel" />
-<param name="console" value="video5268463f37ca4" />
-<param name="nologo" value="true" />
-<param name="nojava" value="true" />
-<param name="center" value="true" />
-<param name="pluginspage" value="http://www.real.com/player/" /></object>';
+		$expected = '<object type="application/vnd.rn-realmedia" data="/media/static/vid/video-rm.rm" classid="clsid:CFCDAA03-8BE4-11cf-B84B-0020AFBBCCFA"><param name="src" value="/media/static/vid/video-rm.rm"/>
+<param name="controls" value="ControlPanel"/>
+<param name="console" value="video5268463f37ca4"/>
+<param name="nologo" value="true"/>
+<param name="nojava" value="true"/>
+<param name="center" value="true"/>
+<param name="pluginspage" value="http://www.real.com/player/"/></object>';
 		$pattern = str_replace('video5268463f37ca4', 'video.{13}', preg_quote($expected, '/'));
 		$this->assertRegExp('/^' . $pattern . '$/', $result);
 
@@ -275,50 +299,50 @@ class MediaHelperTest extends CakeTestCase {
 			'video-mov.mov' => $this->Data->settings['static'] . 'vid/video-mov.mov'
 		));
 		$result = $this->Media->embedAsObject('vid/video-mov');
-		$expected = '<object type="video/quicktime" data="/media/static/vid/video-mov.mov" classid="clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B" codebase="http://www.apple.com/qtactivex/qtplugin.cab" ><param name="src" value="/media/static/vid/video-mov.mov" />
-<param name="controller" value="true" />
-<param name="pluginspage" value="http://www.apple.com/quicktime/download/" /></object>';
+		$expected = '<object type="video/quicktime" data="/media/static/vid/video-mov.mov" classid="clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B" codebase="http://www.apple.com/qtactivex/qtplugin.cab"><param name="src" value="/media/static/vid/video-mov.mov"/>
+<param name="controller" value="true"/>
+<param name="pluginspage" value="http://www.apple.com/quicktime/download/"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'video-mpg.mpg' => $this->Data->settings['static'] . 'vid/video-mpg.mpg'
 		));
 		$result = $this->Media->embedAsObject('vid/video-mpg');
-		$expected = '<object type="video/mpeg" data="/media/static/vid/video-mpg.mpg" ><param name="src" value="/media/static/vid/video-mpg.mpg" /></object>';
+		$expected = '<object type="video/mpeg" data="/media/static/vid/video-mpg.mpg"><param name="src" value="/media/static/vid/video-mpg.mpg"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'video-swf.swf' => $this->Data->settings['static'] . 'vid/video-swf.swf'
 		));
 		$result = $this->Media->embedAsObject('vid/video-swf');
-		$expected = '<object type="application/x-shockwave-flash" data="/media/static/vid/video-swf.swf" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab" ><param name="movie" value="/media/static/vid/video-swf.swf" />
-<param name="wmode" value="transparent" />
-<param name="FlashVars" value="playerMode=embedded" />
-<param name="quality" value="best" />
-<param name="scale" value="noScale" />
-<param name="salign" value="TL" />
-<param name="pluginspage" value="http://www.adobe.com/go/getflashplayer" /></object>';
+		$expected = '<object type="application/x-shockwave-flash" data="/media/static/vid/video-swf.swf" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab"><param name="movie" value="/media/static/vid/video-swf.swf"/>
+<param name="wmode" value="transparent"/>
+<param name="FlashVars" value="playerMode=embedded"/>
+<param name="quality" value="best"/>
+<param name="scale" value="noScale"/>
+<param name="salign" value="TL"/>
+<param name="pluginspage" value="http://www.adobe.com/go/getflashplayer"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'application-pdf.pdf' => $this->Data->settings['static'] . 'doc/application-pdf.pdf'
 		));
 		$result = $this->Media->embedAsObject('doc/application-pdf');
-		$expected = '<object type="application/pdf" data="/media/static/doc/application-pdf.pdf" ><param name="src" value="/media/static/doc/application-pdf.pdf" />
-<param name="toolbar" value="true" />
-<param name="scrollbar" value="true" />
-<param name="navpanes" value="true" /></object>';
+		$expected = '<object type="application/pdf" data="/media/static/doc/application-pdf.pdf"><param name="src" value="/media/static/doc/application-pdf.pdf"/>
+<param name="toolbar" value="true"/>
+<param name="scrollbar" value="true"/>
+<param name="navpanes" value="true"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$this->Data->getFile(array(
 			'audio-mp3.mp3' => $this->Data->settings['static'] . 'aud/audio-mp3.mp3'
 		));
 		$result = $this->Media->embedAsObject('aud/audio-mp3');
-		$expected = '<object type="audio/mpeg" data="/media/static/aud/audio-mp3.mp3" ><param name="src" value="/media/static/aud/audio-mp3.mp3" /></object>';
+		$expected = '<object type="audio/mpeg" data="/media/static/aud/audio-mp3.mp3"><param name="src" value="/media/static/aud/audio-mp3.mp3"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Media->embedAsObject('img/image-png');
-		$expected = '<object type="image/png" data="/media/static/img/image-png.png" ><param name="src" value="/media/static/img/image-png.png" /></object>';
+		$expected = '<object type="image/png" data="/media/static/img/image-png.png"><param name="src" value="/media/static/img/image-png.png"/></object>';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Media->embedAsObject('non-existent');

--- a/Test/Case/View/Helper/MediaHelperTest.php
+++ b/Test/Case/View/Helper/MediaHelperTest.php
@@ -133,17 +133,34 @@ class MediaHelperTest extends CakeTestCase {
 			$this->Data->settings['base'] . 'theme' . DS  => 'media/theme/'
 		);
 		$this->assertEqual($result, $expected);
+
+		$settings = array(
+			'paths' => array(
+				$this->Data->settings['static']               => 'media/static/',
+				$this->Data->settings['base'] . 'theme' . DS  => 'media/theme/'
+			)
+		);
+		$MediaHelper = new MockMediaHelper($this->View, $settings);
+
+		$result = $MediaHelper->paths();
+		$expected = array(
+			$this->Data->settings['static']               => MEDIA_STATIC_URL,
+			MEDIA_TRANSFER                                => MEDIA_TRANSFER_URL,
+			MEDIA_FILTER                                  => MEDIA_FILTER_URL,
+			$this->Data->settings['base'] . 'theme' . DS  => 'media/theme/'
+		);
+		$this->assertEqual($result, $expected);
 	}
 
 	public function testConstructWithCustomPathsAndConfigFile() {
 		$settings = array(
 			'configFile' => 'media_helper.php',
-			'paths' => array(
+			'paths'      => array(
 				$this->Data->settings['static']               => 'media/static/',
 				$this->Data->settings['base'] . 'theme' . DS  => 'media/theme/'
-			),
+			)
 		);
-		$MediaHelper = new MockMediaHelper($this->View, $settings);
+		$MediaHelper = new MockMediaHelper(new View(null), $settings);
 
 		$result = $MediaHelper->paths();
 		$expected = array(
@@ -156,6 +173,30 @@ class MediaHelperTest extends CakeTestCase {
 
 		$result = $MediaHelper->Html->useTag('foo', array('bar' => 'baz', 'qux' => true));
 		$expected = '<foo bar="baz" qux="qux"/>';
+		$this->assertEqual($result, $expected);
+
+		$result = $MediaHelper->Html->useTag('image', 'foo', array('bar' => 'baz', 'ismap' => true));
+		$expected = '<img src="foo"  bar="baz" ismap="ismap"/>';
+		$this->assertEqual($result, $expected);
+
+		$result = $MediaHelper->Html->useTag('audio', array('foo' => 'bar'), '<source/>', '<fallback/>');
+		$expected = '<audio foo="bar"><source/><fallback/></audio>';
+		$this->assertEqual($result, $expected);
+
+		$result = $MediaHelper->Html->useTag('video', array('foo' => 'bar'), '<source/>', '<fallback/>');
+		$expected = '<video foo="bar"><source/><fallback/></video>';
+		$this->assertEqual($result, $expected);
+
+		$result = $MediaHelper->Html->useTag('source', array('foo' => 'bar'));
+		$expected = '<source foo="bar"/>';
+		$this->assertEqual($result, $expected);
+
+		$result = $MediaHelper->Html->useTag('object', array('foo' => 'bar'), '<param/>', '<fallback/>');
+		$expected = '<object foo="bar"><param/><fallback/></object>';
+		$this->assertEqual($result, $expected);
+
+		$result = $MediaHelper->Html->useTag('param', array('foo' => 'bar'));
+		$expected = '<param foo="bar"/>';
 		$this->assertEqual($result, $expected);
 	}
 

--- a/View/Helper/MediaHelper.php
+++ b/View/Helper/MediaHelper.php
@@ -18,7 +18,7 @@
 
 App::uses('Folder', 'Utility');
 App::uses('Set', 'Utility');
-App::uses('HtmlHelper', 'View/Helper');
+App::uses('AppHelper', 'View/Helper');
 
 require_once 'Mime/Type.php';
 
@@ -45,8 +45,17 @@ require_once 'Mime/Type.php';
  * @see           MediaHelper::__construct()
  * @link          http://book.cakephp.org/2.0/en/views/helpers.html
  * @package       Media.View.Helper
+ *
+ * @property HtmlHelper $Html
  */
-class MediaHelper extends HtmlHelper {
+class MediaHelper extends AppHelper {
+
+/**
+ * Helpers
+ *
+ * @var array
+ */
+	public $helpers = array('Html');
 
 /**
  * Tags
@@ -182,7 +191,7 @@ class MediaHelper extends HtmlHelper {
 			$link = $options['url'];
 			unset($options['url']);
 
-			return $this->link($this->embed($paths, $options), $link, array(
+			return $this->Html->link($this->embed($paths, $options), $link, array(
 				'escape' => false
 			));
 		}
@@ -225,7 +234,7 @@ class MediaHelper extends HtmlHelper {
 			case 'image':
 				$attributes = $this->_addDimensions($sources[0]['file'], $attributes);
 
-				return $this->useTag('image',
+				return $this->Html->useTag('image',
 					h($sources[0]['url']),
 					$this->_parseAttributes($attributes)
 				);
@@ -290,7 +299,7 @@ class MediaHelper extends HtmlHelper {
 			$link = $options['url'];
 			unset($options['url']);
 
-			return $this->link($this->embed($paths, $options), $link, array(
+			return $this->Html->link($this->embed($paths, $options), $link, array(
 				'escape' => false
 			));
 		}

--- a/View/Helper/MediaHelper.php
+++ b/View/Helper/MediaHelper.php
@@ -99,16 +99,13 @@ class MediaHelper extends AppHelper {
 	public function __construct(View $View, $settings = array()) {
 		parent::__construct($View, $settings);
 
-		$configFile = 'media_helper.php';
 		$path = dirname(dirname(dirname(__FILE__))) . DS . 'Config' . DS;
+		$this->Html->loadConfig('media_helper.php', $path);
 
 		if (isset($settings['configFile'])) {
-			$configFile = $settings['configFile'];
+			$this->Html->loadConfig($settings['configFile']);
 			unset($settings['configFile']);
-			$path = null;
 		}
-
-		$this->Html->loadConfig($configFile, $path);
 
 		$paths = (array)$settings;
 		if (isset($paths['paths'])) {


### PR DESCRIPTION
As described in https://github.com/bmcclure/CakePHP-Media-Plugin/issues/49#issuecomment-28238733, this patch switches back to extending `AppHelper`, and ditches manual tag generation and overriding `Helper::_parseAttributes()` in favor of using `HtmlHelper::useTag()` and utilizing config files (as suggested by @gBokiau in https://github.com/bmcclure/CakePHP-Media-Plugin/pull/50#issuecomment-28200398) to configure `HtmlHelper` with proper tags and minimizable attributes.

It should be backwards compatible and resolve #50.
