### PR TITLE
Remove workarounds for older PHP versions

### DIFF
--- a/Model/Behavior/TransferBehavior.php
+++ b/Model/Behavior/TransferBehavior.php
@@ -317,10 +317,6 @@ class TransferBehavior extends ModelBehavior {
 			return null;
 		}
 
-		if (!isset($resource['filename'])) { /* PHP < 5.2.0 */
-			$length = isset($resource['extension']) ? strlen($resource['extension']) + 1 : 0;
-			$resource['filename'] = substr($resource['basename'], 0, - $length);
-		}
 		return $resource;
 	}
 
@@ -890,17 +886,13 @@ class TransferBehavior extends ModelBehavior {
 		/* @var $extension string */
 		/* @var $filename string */
 
-		if (!isset($filename)) { /* PHP < 5.2.0 */
-			$filename = substr($basename, 0, isset($extension) ? - (strlen($extension) + 1) : 0);
-		}
 		$newFilename = $filename;
 
 		$Folder = new Folder($dirname);
 		$names = $Folder->find($filename . '.*');
 
-		foreach ($names as &$name) { /* PHP < 5.2.0 */
-			$length = strlen(pathinfo($name, PATHINFO_EXTENSION));
-			$name = substr(basename($name), 0, $length ? - ($length + 1) : 0);
+		foreach ($names as &$name) {
+			$name = pathinfo($name, PATHINFO_FILENAME);
 		}
 
 		for ($count = 2; in_array($newFilename, $names); $count++) {

--- a/View/Helper/MediaHelper.php
+++ b/View/Helper/MediaHelper.php
@@ -511,10 +511,6 @@ class MediaHelper extends AppHelper {
 		/* @var $extension string */
 		/* @var $filename string */
 
-		if (!isset($filename)) { /* PHP < 5.2.0 */
-			$filename = substr($basename, 0, isset($extension) ? - (strlen($extension) + 1) : 0);
-		}
-
 		foreach ($bases as $base) {
 			if (file_exists($base . $path)) {
 				return $base . $path;


### PR DESCRIPTION
This patch removes the workarounds for PHP versions < 5.2.0 where `PATHINFO_FILENAME` support is missing. The CakePHP core already requires PHP 5.2.8 as a minimum, not to mention that this functionality is used in the `GeneratorBehaviour` class [since ages](https://github.com/davidpersson/media/commit/3dc0a99542f93e38f279f8dcd070639143cd4624#diff-c773dbc49ea9eafb6801aeea766ab820), so these workarounds should be be safe to drop.
