### PR TITLE
Add support for regenerating metadata

### DIFF
--- a/Model/Behavior/MetaBehavior.php
+++ b/Model/Behavior/MetaBehavior.php
@@ -103,7 +103,7 @@ class MetaBehavior extends ModelBehavior {
  * @return mixed False if the operation should abort. Any other result will continue.
  */
 	public function beforeSave(Model $Model, $options = array()) {
-		if ($Model->exists() || !isset($Model->data[$Model->alias]['file'])) {
+		if (!isset($Model->data[$Model->alias]['file'])) {
 			return true;
 		}
 		extract($this->settings[$Model->alias]);

--- a/Test/Case/Model/Behavior/MetaBehaviorTest.php
+++ b/Test/Case/Model/Behavior/MetaBehaviorTest.php
@@ -83,4 +83,33 @@ class MetaBehaviorTest extends BaseBehaviorTest {
 		$this->assertTrue(Set::matches('/Song/mime_type',$result));
 	}
 
+	public function testRegenerate() {
+		$Model = ClassRegistry::init('Song');
+		$Model->Behaviors->load('Media.Meta', $this->behaviorSettings['Meta']);
+
+		$data = array('Song' => array('file' => $this->record1File));
+		$this->assertTrue(!!$Model->save($data));
+		$Model->Behaviors->unload('Media.Meta');
+
+		$id = $Model->getLastInsertID();
+		$result = $Model->findById($id);
+		$checksum = $result['Song']['checksum'];
+		$this->assertEqual($result['Song']['checksum'], md5_file($this->record1File));
+
+
+		$Model->Behaviors->load('Media.Meta', $this->behaviorSettings['Meta']);
+
+		$file = $this->Data->getFile(
+			array('image-jpg.jpg' => $this->Data->settings['transfer'] . 'ta.jpg')
+		);
+
+		$data = array('Song' => array('id' => $id, 'file' => $file));
+		$this->assertTrue(!!$Model->save($data));
+		$Model->Behaviors->unload('Media.Meta');
+
+		$result = $Model->findById($id);
+		$this->assertNotEquals($result['Song']['checksum'], $checksum);
+		$this->assertEqual($result['Song']['checksum'], md5_file($file));
+	}
+
 }


### PR DESCRIPTION
Currently metadata is only saved when a record is created, thus the data in the record becomes invalid when a file is replaced.

This problem is somewhat covert by the metadata injection that takes place after retrieving a record, however this only works when the model which has the behavior attached is queried directly, and of course the data in database should be valid anyway.

This patch adds support for regenerating metadata when a record is updated.

See also https://github.com/davidpersson/media/issues/67
