### PR TITLE
Metadata cleanup, configurable caching and additional tests

### DIFF
--- a/Model/Behavior/MetaBehavior.php
+++ b/Model/Behavior/MetaBehavior.php
@@ -164,6 +164,8 @@ class MetaBehavior extends ModelBehavior {
 		}
 		$checksum = $File->md5(true);
 
+		$data = array();
+
 		if (isset($this->__cached[$Model->alias][$checksum])) {
 			$data = $this->__cached[$Model->alias][$checksum];
 		}

--- a/Model/Behavior/MetaBehavior.php
+++ b/Model/Behavior/MetaBehavior.php
@@ -24,7 +24,7 @@ require_once 'Mime/Type.php';
 require_once 'Media/Info.php';
 
 /**
- * Coupler Behavior Class
+ * Meta Behavior Class
  *
  * If you set metadataLevel to a value greater then zero, you’ll get additional
  * metadata on each consecutive find operation.

--- a/Model/Behavior/MetaBehavior.php
+++ b/Model/Behavior/MetaBehavior.php
@@ -42,6 +42,22 @@ require_once 'Media/Info.php';
 class MetaBehavior extends ModelBehavior {
 
 /**
+ * Cache configuration.
+ *
+ * config
+ *   The name of the cache configuration to use
+ *
+ * keyPrefix
+ *   The prefix to use for the cache data identifier
+ *
+ * @var array
+ */
+	public static $cacheConfig = array(
+		'config'    => 'default',
+		'keyPrefix' => 'media_metadata_'
+	);
+
+/**
  * Default settings
  *
  * metadataLevel
@@ -77,7 +93,10 @@ class MetaBehavior extends ModelBehavior {
 
 		$this->settings[$Model->alias] = array_merge($this->settings[$Model->alias], (array) $settings);
 
-		$this->__cached[$Model->alias] = Cache::read('media_metadata_' . $Model->alias);
+		extract(MetaBehavior::$cacheConfig);
+		/* @var $config string */
+		/* @var $keyPrefix string */
+		$this->__cached[$Model->alias] = Cache::read($keyPrefix . $Model->alias, $config);
 	}
 
 /**
@@ -86,9 +105,13 @@ class MetaBehavior extends ModelBehavior {
  * @return void
  */
 	public function __destruct() {
+		extract(MetaBehavior::$cacheConfig);
+		/* @var $config string */
+		/* @var $keyPrefix string */
+
 		foreach ($this->__cached as $alias => $data) {
 			if ($data) {
-				Cache::write('media_metadata_' . $alias, $data);
+				Cache::write($keyPrefix . $alias, $data, $config);
 			}
 		}
 	}

--- a/Model/Behavior/MetaBehavior.php
+++ b/Model/Behavior/MetaBehavior.php
@@ -157,7 +157,6 @@ class MetaBehavior extends ModelBehavior {
 		if ($level < 1) {
 			return array();
 		}
-		extract($this->settings[$Model->alias]);
 		$File = new File($file);
 
 		if (!$File->readable()) {

--- a/Test/Case/Model/Behavior/MetaBehaviorTest.php
+++ b/Test/Case/Model/Behavior/MetaBehaviorTest.php
@@ -17,6 +17,7 @@
  */
 
 App::uses('Set', 'Utility');
+App::uses('MetaBehavior', 'Media.Model/Behavior');
 
 require_once dirname(dirname(dirname(__FILE__))) . DS . 'constants.php';
 require_once dirname(__FILE__) . DS . 'BehaviorTestBase.php';
@@ -29,6 +30,8 @@ require_once dirname(__FILE__) . DS . 'BehaviorTestBase.php';
 class MetaBehaviorTest extends BaseBehaviorTest {
 
 	public $record1File;
+
+	public $oldCacheConfig;
 
 	public function setUp() {
 		parent::setUp();
@@ -46,6 +49,18 @@ class MetaBehaviorTest extends BaseBehaviorTest {
 			'image-png.png' => $this->Data->settings['static'] . 'img/image-png.png'
 		));
 
+		$this->oldCacheConfig = MetaBehavior::$cacheConfig;
+		MetaBehavior::$cacheConfig['keyPrefix'] = 'media_metadata_test_';
+
+		extract(MetaBehavior::$cacheConfig);
+		/* @var $config string */
+		/* @var $keyPrefix string */
+		Cache::delete($keyPrefix . 'Song', $config);
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		MetaBehavior::$cacheConfig = $this->oldCacheConfig;
 	}
 
 	public function testSetup() {
@@ -110,6 +125,96 @@ class MetaBehaviorTest extends BaseBehaviorTest {
 		$result = $Model->findById($id);
 		$this->assertNotEquals($result['Song']['checksum'], $checksum);
 		$this->assertEqual($result['Song']['checksum'], md5_file($file));
+	}
+
+	public function testMetadata() {
+		$Model = ClassRegistry::init('Song');
+		$Model->Behaviors->load('Media.Meta', $this->behaviorSettings['Meta']);
+
+		$result = $Model->metadata($this->record1File, 0);
+		$expected = array();
+		$this->assertEqual($result, $expected);
+
+		$result = $Model->metadata($this->record1File, 1);
+		$expected = array(
+			'size'      => 2032,
+			'mime_type' => 'image/png',
+			'checksum'  => '0ec724ac451b85f09e4652d29eff943e',
+		);
+		$this->assertEqual($result, $expected);
+
+		$result = $Model->metadata($this->record1File, 2);
+		$expected = array(
+			'ratio'       => 1.2962962962963,
+			'known_ratio' => '4:3',
+			'megapixel'   => 0,
+			'quality'     => 1,
+			'width'       => 70,
+			'height'      => 54,
+			'bits'        => 8,
+			'size'        => 2032,
+			'mime_type'   => 'image/png',
+			'checksum'    => '0ec724ac451b85f09e4652d29eff943e',
+		);
+		$this->assertEqual($result, $expected);
+	}
+
+	public function testCaching() {
+		extract(MetaBehavior::$cacheConfig);
+		/* @var $config string */
+		/* @var $keyPrefix string */
+
+		$Model = ClassRegistry::init('Song');
+		$Model->Behaviors->load('Media.Meta', $this->behaviorSettings['Meta']);
+		$Model->metadata($this->record1File, 2);
+
+		// remove all references so that the destructor is triggered
+		$Model->Behaviors->unload('Media.Meta');
+		ClassRegistry::removeObject('Media..MetaBehavior'); // https://github.com/cakephp/cakephp/issues/2306
+		ClassRegistry::removeObject('MetaBehavior');
+
+		$result = Cache::read($keyPrefix . $Model->alias, $config);
+		$expected = array(
+			'0ec724ac451b85f09e4652d29eff943e' => array(
+				1 => array(
+					'size'      => 2032,
+					'mime_type' => 'image/png',
+					'checksum'  => '0ec724ac451b85f09e4652d29eff943e'
+				),
+				2 => array(
+					'ratio'       => 1.2962962962963,
+					'known_ratio' => '4:3',
+					'megapixel'   => 0,
+					'quality'     => 1,
+					'width'       => 70,
+					'height'      => 54,
+					'bits'        => 8
+				)
+			)
+		);
+		$this->assertEqual($result, $expected);
+
+		$expected['0ec724ac451b85f09e4652d29eff943e'][2]['foo'] = 'bar';
+		Cache::write($keyPrefix . $Model->alias, $expected, $config);
+
+		$Model->Behaviors->load('Media.Meta', $this->behaviorSettings['Meta']);
+		$Model->metadata($this->record1File, 2);
+
+		$result = $Model->metadata($this->record1File, 2);
+		$expected = array(
+			'ratio'       => 1.2962962962963,
+			'known_ratio' => '4:3',
+			'megapixel'   => 0,
+			'quality'     => 1,
+			'width'       => 70,
+			'height'      => 54,
+			'bits'        => 8,
+			'foo'         => 'bar',
+			'size'        => 2032,
+			'mime_type'   => 'image/png',
+			'checksum'    => '0ec724ac451b85f09e4652d29eff943e',
+		);
+		$this->assertEqual($result, $expected);
 	}
 
 }


### PR DESCRIPTION
The title and the comments more or less speak for themselves, this patch cleans up some sloppiness and fixes a bug where the `$level` argument in `MetaBehavior::metadata()` has no effect, also it makes metadata caching configurable (as in makes it possible to choose the cache configuration and the key prefix to use) and adds some tests.
