### PR TITLE
Add 'forceDelete' setting to CouplerBehavior

### DIFF
--- a/Model/Attachment.php
+++ b/Model/Attachment.php
@@ -52,7 +52,8 @@ class Attachment extends MediaAppModel {
 		),
 		'Media.Polymorphic',
 		'Media.Coupler' => array(
-			'baseDirectory' => MEDIA_TRANSFER
+			'baseDirectory' => MEDIA_TRANSFER,
+			'forceDelete'   => false
 		),
 		'Media.Meta' => array(
 			'level' => 2

--- a/Model/Behavior/CouplerBehavior.php
+++ b/Model/Behavior/CouplerBehavior.php
@@ -57,11 +57,15 @@ class CouplerBehavior extends ModelBehavior {
  *
  * baseDirectory
  *   An absolute path (with trailing slash) to a directory which will be stripped off the file path
+ * forceDelete
+ *   If set to true, record deletion will proceed even if original media file was not
+ *   found in baseDirectory. Defaults to false. This will not delete generated versions
  *
  * @var array
  */
 	protected $_defaultSettings = array(
-		'baseDirectory' => MEDIA_TRANSFER
+		'baseDirectory' => MEDIA_TRANSFER,
+		'forceDelete' => false
 	);
 
 /**
@@ -180,7 +184,8 @@ class CouplerBehavior extends ModelBehavior {
 		$file .= DS . $result[$Model->alias]['basename'];
 
 		$File = new File($file);
-		return $File->delete();
+		$success = $File->delete();
+		return ($this->settings[$Model->alias]['forceDelete']) ? true : $success;
 	}
 
 /**


### PR DESCRIPTION
Current behavior :
When deleting the record for a media, if the original file is not found in the transfer directory, record deletion is interrupted without any warning

Proposed fix:
A $forceDelete setting is added to CouplerBeharvior. If set to true, record deletion will proceed even if original media file was not found in baseDirectory. Defaults to false (but does this make sense, see bullet point)

Further thinking:
Should a warning be issued when the file is not found instead or in addition to this behavior ? Would the best approach to this be to use php's unlink() method instead of File::delete() (as unlink() issues an E_WARNING when the file is not found whereas File::delete() doesn't ) ?
- Is there any scenario where it makes sense _not_ to delete the record when the file is not found ? Deleting the record is the prime function of delete(), and should thus proceed whenever possible, while file deletion could be considered an added benefit
