### PR TITLE
Fix a problem where test data files cannot be unlinked on Windows

### DIFF
--- a/Test/Fixture/TestData.php
+++ b/Test/Fixture/TestData.php
@@ -180,6 +180,7 @@ class TestData extends Object {
 
 		$File->write($string);
 		$File->offset(0);
+		$File->close();
 
 		$this->Files[$alias] =& $File;
 		return $File->pwd();


### PR DESCRIPTION
The handles of generated test data files were left open, which can lead to problems on Windows based systems where files cannot be deleted, and `unlink()` throws "_permission denied_" errors.
