### PR TITLE
Remove marker check

### DIFF
--- a/Model/Behavior/TransferBehavior.php
+++ b/Model/Behavior/TransferBehavior.php
@@ -689,14 +689,6 @@ class TransferBehavior extends ModelBehavior {
 	public function checkLocation(Model $Model, $field, $allow = true) {
 		extract($this->runtime[$Model->alias]);
 
-		foreach ((array)$allow as $allowed) {
-			if (strpos(':', $allowed) !== false) {
-				$message  = "TransferBehavior::checkLocation - ";
-				$message .= "Makers cannot be used in parameters for this method anymore. ";
-				$message .= "Please use predefined constants instead.";
-				trigger_error($message, E_USER_NOTICE);
-			}
-		}
 		foreach (array('source', 'temporary', 'destination') as $type) {
 			if ($type == 'temporary' && empty($$type)) {
 				continue;


### PR DESCRIPTION
Markers aren't supported anymore since ~5 years in the 1.3 version, and
they never were in the 2.0 version, so it's safe to remove this check.

See ff2b25ad8b9297ea27a22246b987353fb47fc6e1 for reference.
