### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+	"name": "bmcclure/cakephp-media-plugin",
+	"description": "CakePHP Media Plugin",
+	"type": "cakephp-plugin",
+	"keywords": ["cakephp", "media", "upload", "convert"],
+	"homepage": "https://github.com/bmcclure/CakePHP-Media-Plugin",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Ben McClure",
+			"role": "Maintainer",
+			"homepage": "https://github.com/bmcclure"
+		},
+		{
+			"name": "Community",
+			"role": "Contributor",
+			"homepage": "https://github.com/bmcclure/CakePHP-Media-Plugin/graphs/contributors"
+		}
+	],
+	"support": {
+		"issues": "https://github.com/bmcclure/CakePHP-Media-Plugin/issues",
+		"source": "https://github.com/bmcclure/CakePHP-Media-Plugin"
+	},
+	"require": {
+		"php": ">=5.2.8",
+		"composer/installers": "*"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-cake-2.0": "2.x-dev"
+		},
+		"installer-name": "Media"
+	}
+}


### PR DESCRIPTION
This patch adds initial support for composer. Hopefully I got this right.

In order for package consumers to have this work out of the box, ie without additionally [adding the repository URL to the local composer configuration](https://getcomposer.org/doc/05-repositories.md#vcs), the repository still needs to be registered with https://packagist.org. I guess anyone can do that, not sure, I never did it before.

Once merged and registered it should be possible to include the plugin using for example

``` json
{
    "require": {
        "bmcclure/cakephp-media-plugin": "2.*@dev"
    }
}
```
